### PR TITLE
[CI] Fix error: Compilation search paths unable to resolve module dependency: 'SwiftCompilerPlugin'

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,6 +47,9 @@ let package = Package(
 			dependencies: [
 				"TaggedMacroPlugin",
 				.product(name: "MacroTesting", package: "swift-macro-testing"),
+				// fixes error: Compilation search paths unable to resolve module dependency: 'SwiftCompilerPlugin'
+				// might be related to swift-syntax prebuilts?
+				.product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
 			]
 		),
 	]


### PR DESCRIPTION
This seems to happen when prebuilts are turned on. No idea why.